### PR TITLE
docs: Fix PyPI Images (v0.1.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ LoFi Gate is a **signal-first** verification proxy. It wraps your existing tools
 
 ## The Old Way
 
-![The Old Way](assets/images/testing-old-way.gif)
+![The Old Way](https://github.com/LoFi-Monk/lofi-gate/raw/main/assets/images/testing-old-way.gif)
 
 ## The New Way
 
-![The New Way](assets/images/testing-lofi-way.gif)
+![The New Way](https://github.com/LoFi-Monk/lofi-gate/raw/main/assets/images/testing-lofi-way.gif)
 
 In extreme cases (complex failures, verbose frameworks), we've measured single test failures producing 15,000+ tokens.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lofi-gate"
-version = "0.1.1"
+version = "0.1.2"
 description = "Signal-first verification for AI coding agents."
 readme = "README.md"
 authors = [{ name = "LoFi Monk", email = "lofi@example.com" }]


### PR DESCRIPTION
Changes relative image paths to absolute GitHub URLs so they render correctly on PyPI.